### PR TITLE
Fix achievements loading order

### DIFF
--- a/public/leaderboard.html
+++ b/public/leaderboard.html
@@ -732,13 +732,13 @@ async function loadAllData() {
         }
 
         // Cargar ranking semanal
-        loadWeeklyRanking();
-        
+        await loadWeeklyRanking();
+
         // Cargar ranking ELO
-        loadEloRanking();
-        
+        await loadEloRanking();
+
         // Cargar logros
-        loadAchievements();
+        await loadAchievements();
 
     } catch (error) {
         console.error('Error general:', error);


### PR DESCRIPTION
## Summary
- await weekly ranking, ELO ranking and achievements during initial load

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f57490a1c83329834b16f3ca0bbe9